### PR TITLE
Added #[repr(transparent)].

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][1], and this project adheres to [Semantic Versioning][2].
 
+## [0.2.1] 2023-10-09
+### Added
+- `#[repr(transparent)]` to `Amount, Instant, Id, DisplayProxy`. See also
+   <https://doc.rust-lang.org/reference/type-layout.html#the-transparent-representation>.
+
+### Updated
+- `Cargo.lock`
+
 ## [0.2.0] 2019-11-09
 ### Added
  - `Instant` archetype supporting instant/amount arithmetics.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phantom_newtype"
 description = "Lightweight newtypes without macros."
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Roman Kashitsyn <roman.kashitsyn@gmail.com>"]
 repository = "https://github.com/roman-kashitsyn/phantom-newtype"
 

--- a/src/amount.rs
+++ b/src/amount.rs
@@ -143,6 +143,7 @@ use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Sub, SubAssign};
 /// let n_from_thread = std::thread::spawn(|| &N).join().unwrap();
 /// assert_eq!(N, *n_from_thread);
 /// ```
+#[repr(transparent)]
 pub struct Amount<Unit, Repr>(Repr, PhantomData<std::sync::Mutex<Unit>>);
 
 impl<Unit, Repr: Copy> Amount<Unit, Repr> {

--- a/src/displayer.rs
+++ b/src/displayer.rs
@@ -28,6 +28,7 @@ pub trait DisplayerOf<T> {
 
 /// An object `DisplayProxy`, when is asked to display itself,
 /// displays `T` using the specified `Displayer` instead.
+#[repr(transparent)]
 pub struct DisplayProxy<'a, T, Displayer>
 where
     Displayer: DisplayerOf<T>,

--- a/src/id.rs
+++ b/src/id.rs
@@ -135,6 +135,7 @@ use std::marker::PhantomData;
 /// assert_eq!(serde_json::to_string(&user_id).unwrap(), serde_json::to_string(&repr).unwrap());
 /// }
 /// ```
+#[repr(transparent)]
 pub struct Id<Entity, Repr>(Repr, PhantomData<std::sync::Mutex<Entity>>);
 
 impl<Entity, Repr> Id<Entity, Repr> {

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -137,6 +137,7 @@ use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Sub, SubAssign};
 /// let instant_from_thread = std::thread::spawn(|| &I).join().unwrap();
 /// assert_eq!(I, *instant_from_thread);
 /// ```
+#[repr(transparent)]
 pub struct Instant<Unit, Repr>(Repr, PhantomData<std::sync::Mutex<Unit>>);
 
 impl<Unit, Repr: Copy> Instant<Unit, Repr> {


### PR DESCRIPTION
Thank you for this library Roman.
FYI It has a first dependency: https://crates.io/crates/phantom_newtype/reverse_dependencies -> https://crates.io/crates/test-binary-features (early, work in progress).

This PR is to apply https://doc.rust-lang.org/reference/type-layout.html#the-transparent-representation.